### PR TITLE
Fix --reverse option for the Horizontal and Vertical animation presets

### DIFF
--- a/depthflow/animation.py
+++ b/depthflow/animation.py
@@ -363,6 +363,7 @@ class Animation(ClassEnum):
                     amplitude = 0.8*self.intensity,
                     phase     = self.phase,
                     cycles    = 1.00,
+                    reverse   = self.reverse,
                 ).apply(scene)
             else:
                 (Animation.Sine if self.smooth else Animation.Triangle)(
@@ -370,6 +371,7 @@ class Animation(ClassEnum):
                     amplitude = self.intensity,
                     phase     = -0.25,
                     cycles    = 0.50,
+                    reverse   = self.reverse,
                 ).apply(scene)
 
     class Horizontal(PresetBase):
@@ -391,6 +393,7 @@ class Animation(ClassEnum):
                     amplitude = 0.8*self.intensity,
                     phase     = self.phase,
                     cycles    = 1.00,
+                    reverse   = self.reverse,
                 ).apply(scene)
             else:
                 (Animation.Sine if self.smooth else Animation.Triangle)(
@@ -398,6 +401,7 @@ class Animation(ClassEnum):
                     amplitude = self.intensity,
                     phase     = -0.25,
                     cycles    = 0.50,
+                    reverse   = self.reverse,
                 ).apply(scene)
 
     class Zoom(PresetBase):


### PR DESCRIPTION
This PR fixes a problem with the `--reverse` option not being passed to the scene in the horizontal and vertical animation presets. This meant that it was not considered and the following commands were creating the same output:

```
depthflow vertical --no-loop input -i <PATH_TO_IMAGE> main 
depthflow vertical --reverse --no-loop input -i <PATH_TO_IMAGE> main 
```

Resolves #89 