### PR TITLE
Fix CLI input command crashing before build() and immutable tuple offset mutation

### DIFF
--- a/depthflow/animation.py
+++ b/depthflow/animation.py
@@ -51,14 +51,14 @@ class Horizontal(Action):
     wave: Sine = Field(default_factory=Sine)
 
     def apply(self, state: DepthState, time: float) -> None:
-        state.offset[0] = self.wave.at(time) # type: ignore
+        state.offset = (self.wave.at(time), state.offset[1])
 
 class Vertical(Action):
     """Apply a vertical motion in offsets"""
     wave: Sine = Field(default_factory=Sine)
 
     def apply(self, state: DepthState, time: float) -> None:
-        state.offset[1] = self.wave.at(time) # type: ignore
+        state.offset = (state.offset[0], self.wave.at(time))
 
 class Circle(Action):
     """Apply a circular motion in offsets"""

--- a/depthflow/scene.py
+++ b/depthflow/scene.py
@@ -74,17 +74,24 @@ class DepthScene(ShaderScene):
                 progressbar=True,
             ))
 
-        # Load estimate input image
-        image = imageio.imread(image)
-        depth = imageio.imread(depth) \
+        # Load and estimate input image
+        image_arr = imageio.imread(image)
+        depth_arr = imageio.imread(depth) \
             if (depth is not None) else \
-            self.estimator.estimate(image)
+            self.estimator.estimate(image_arr)
 
-        self.image.from_numpy(image)
-        self.depth.from_numpy(depth)
+        # Textures are only available after build(); store for setup() if not yet built
+        if not hasattr(self, 'image'):
+            object.__setattr__(self, '_pending_image', image_arr)
+            object.__setattr__(self, '_pending_depth', depth_arr)
+            return
+
+        self.image.from_numpy(image_arr)
+        self.depth.from_numpy(depth_arr)
 
         # Match rendering resolution to image
-        self.resolution = self.image.size
+        w, h = self.image.size
+        self.resize(width=w, height=h)
 
     # ------------------------------------------------------------------------ #
     # Module implementation
@@ -96,7 +103,13 @@ class DepthScene(ShaderScene):
         self.runtime = 5.0
 
     def setup(self) -> None:
-        if self.image.is_empty():
+        pending = getattr(self, '_pending_image', None)
+        if pending is not None:
+            self.image.from_numpy(pending)
+            self.depth.from_numpy(self._pending_depth)
+            w, h = self.image.size
+            self.resize(width=w, height=h)
+        elif self.image.is_empty():
             self.input(None)
 
     def update(self) -> None:


### PR DESCRIPTION
## Summary

Three bugs that prevent `depthflow input --image <path> da2 <animation> main` from working at all in v0.10.0:

- **`scene.py` — AttributeError: 'DepthScene' object has no attribute 'image'**
  The `input` CLI command is dispatched before `build()` runs, so `self.image` and `self.depth` (created in `build()`) don't exist yet. Fix: check if textures are built; if not, store the loaded numpy arrays in pending variables via `object.__setattr__` and apply them in `setup()` after `build()` has run.

- **`scene.py` — TypeError: ShaderScene.resize() takes 1 positional argument but 3 were given**
  `self.resolution = self.image.size` invokes the `resolution` setter which calls `self.resize(*value)`, but `resize()` defines all parameters as keyword-only (`*,`). Fix: call `self.resize(width=w, height=h)` directly.

- **`animation.py` — TypeError: 'tuple' object does not support item assignment**
  `Horizontal` and `Vertical` animations did `state.offset[0] = val` and `state.offset[1] = val`, but `offset` is declared as `tuple[float, float]` in Pydantic and is immutable. Fix: reassign the whole tuple (consistent with how `Circle` already handles it).

## Test plan

- [x] `depthflow input --image <path> da2 circle main --output out.mp4` completes without error
- [x] `depthflow input --image <path> da2 horizontal main --output out.mp4` completes without error
- [x] `depthflow input --image <path> da2 vertical main --output out.mp4` completes without error
- [x] Output MP4 is generated and playable
- [x] Realtime window mode also works (no `--output` flag)